### PR TITLE
3.0.7 Fixed error on null reference

### DIFF
--- a/Scripts/Runtime/TMPro_Private.cs
+++ b/Scripts/Runtime/TMPro_Private.cs
@@ -1473,18 +1473,26 @@ namespace TMPro
             // We need to update the SDF scale or possibly regenerate the text object if lossy scale has changed.
             if (m_havePropertiesChanged == false)
             {
-                float lossyScaleY = m_rectTransform.lossyScale.y;
-
-                // Ignore very small lossy scale changes as their effect on SDF Scale would not be visually noticeable.
-                // Do not update SDF Scale if the text is null or empty
-                if (Mathf.Abs(lossyScaleY - m_previousLossyScaleY) > 0.0001f && m_TextProcessingArray[0].unicode != 0)
+                if (m_rectTransform)
                 {
-                    float scaleDelta = lossyScaleY / m_previousLossyScaleY;
+                    float lossyScaleY = m_rectTransform.lossyScale.y;
 
-                    UpdateSDFScale(scaleDelta);
+                    // Ignore very small lossy scale changes as their effect on SDF Scale would not be visually noticeable.
+                    // Do not update SDF Scale if the text is null or empty
+                    if (Mathf.Abs(lossyScaleY - m_previousLossyScaleY) > 0.0001f && m_TextProcessingArray[0].unicode != 0)
+                    {
+                        float scaleDelta = lossyScaleY / m_previousLossyScaleY;
 
-                    m_previousLossyScaleY = lossyScaleY;
+                        UpdateSDFScale(scaleDelta);
+
+                        m_previousLossyScaleY = lossyScaleY;
+                    }
                 }
+                else
+                {
+                    Debug.LogError("the element m_rectTransform is null, added else otherwise the texts disappeared");
+                }
+                
             }
 
             // Added to handle legacy animation mode.

--- a/Scripts/Runtime/TMPro_Private.cs
+++ b/Scripts/Runtime/TMPro_Private.cs
@@ -1490,7 +1490,16 @@ namespace TMPro
                 }
                 else
                 {
-                    Debug.LogError("the element m_rectTransform is null, added else otherwise the texts disappeared");
+                    
+                    /*
+                        AnotheReality: we added a debug log warning just to check where the TMPro error was occurring
+                        if you see this warning then it means that the texts were previously disappearing at this point but now they don't anymore                
+                        we simply added a check to the m_rectTransform that was returning null and because of that the texts were disappearing
+                    */
+
+                    if(Application.isPlaying){                       
+                        Debug.LogWarning("AnotheReality: this check was added to avoid the TMPro error where the texts were disappearing");
+                    }
                 }
                 
             }


### PR DESCRIPTION
Dear Needle team, we were getting null references on the m_rectTransform that were resulting in the texts disappearing. To avoid this error we simply added a check on the m_rectTransform.  Is it possible that there are some objects that keep references even when destroyed? Anyway this current fix seems to actually fix the problem.